### PR TITLE
Sabard/darwin

### DIFF
--- a/trustedtimestamping/usr/local/bin/ttsPackJSON
+++ b/trustedtimestamping/usr/local/bin/ttsPackJSON
@@ -18,6 +18,13 @@ VERSION=0.0.2
 
 DIGEST_SIZE=256
 
+# check for Mac
+if [ "$(uname)" = "Darwin" ]; then
+    CMD_BASE64="base64 -b 0"
+else
+    CMD_BASE64="$CMD_BASE64"
+fi
+
 DIR_LOCAL_BIN=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 source $DIR_LOCAL_BIN/../../../etc/trustedts/tts.source
 
@@ -35,7 +42,7 @@ if compgen -G "$DIR_TS/*.sha$DIGEST_SIZE" > /dev/null; then
     FILE_HASH=$(find $DIR_TS -name "*.sha$DIGEST_SIZE" -exec basename {} .sha$DIGEST_SIZE \;)
 
     JSON=$(jq ".name = \"$FILE_HASH\"" <(printf '%s' "$JSON"))
-    JSON=$(jq ".hashfile = {\"filename\" : \"$FILE_HASH.sha$DIGEST_SIZE\", \"algorithm\" : \"SHA$DIGEST_SIZE\", \"contents\" : \"$(base64 -w 0 < <(<$DIR_TS/$FILE_HASH.sha$DIGEST_SIZE) )\"} " <(printf '%s' "$JSON"))
+    JSON=$(jq ".hashfile = {\"filename\" : \"$FILE_HASH.sha$DIGEST_SIZE\", \"algorithm\" : \"SHA$DIGEST_SIZE\", \"contents\" : \"$($CMD_BASE64 < <(<$DIR_TS/$FILE_HASH.sha$DIGEST_SIZE) )\"} " <(printf '%s' "$JSON"))
 fi
 
 # check if git hash file exists
@@ -51,19 +58,19 @@ for TSA_idx in $(seq 0 $((${#TSA_names[@]}-1)) ); do
 
     CRLs=()
     for crl in $DIR_TS/tsCRL_${TSA_names[$TSA_idx]}*.crl; do
-        CRLs+=($(base64 -w 0 < <(<$crl) ))
+        CRLs+=($($CMD_BASE64 < <(<$crl) ))
     done
     CRL_JSON=$(jq -n --arg array "${CRLs[*]}" '$array| split(" ")')
 
-    STR_TSREP=$(base64 -w 0 < <(<$DIR_TS/tsReply_${TSA_names[$TSA_idx]}.tsr) )
-    STR_CA=$(base64 -w 0 < <(<$DIR_CA/${TSA_names[$TSA_idx]}CA.pem) )
+    STR_TSREP=$($CMD_BASE64 < <(<$DIR_TS/tsReply_${TSA_names[$TSA_idx]}.tsr) )
+    STR_CA=$($CMD_BASE64 < <(<$DIR_CA/${TSA_names[$TSA_idx]}CA.pem) )
 
     JSON=$(jq ".timestamps += [{ \"authority\" : \"${TSA_names[$TSA_idx]}\", \"url\" : \"${TSA_urls[$TSA_idx]}\", \"reply\" : \"$STR_TSREP\", \"ca\" : \"$STR_CA\", \"crls\" : $CRL_JSON }]" <(printf '%s' "$JSON"))
 done
 
-if [ -v FILE_HASH ]; then
-    FILE_SUFFIX="_$FILE_HASH"
-else
+if [ -n FILE_HASH ]; then
     FILE_SUFFIX=""
+else
+    FILE_SUFFIX="_$FILE_HASH"
 fi
 printf '%s' "$JSON" > timestamps$FILE_SUFFIX.json

--- a/trustedtimestamping/usr/local/bin/ttsPackJSON
+++ b/trustedtimestamping/usr/local/bin/ttsPackJSON
@@ -22,7 +22,7 @@ DIGEST_SIZE=256
 if [ "$(uname)" = "Darwin" ]; then
     CMD_BASE64="base64 -b 0"
 else
-    CMD_BASE64="$CMD_BASE64"
+    CMD_BASE64="base64 -w 0"
 fi
 
 DIR_LOCAL_BIN=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )

--- a/trustedtimestamping/usr/local/bin/ttsVerify
+++ b/trustedtimestamping/usr/local/bin/ttsVerify
@@ -22,8 +22,12 @@ DIGEST_SIZE=256
 
 # check for Mac
 if [ "$(uname)" = "Darwin" ]; then
+    CMD_CSPLIT=gcsplit
+    CMD_DATE=("date" "-jf" "%b %e %H:%M:%S %Y %Z")
     CMD_SHA="shasum -a $DIGEST_SIZE"
 else
+    CMD_CSPLIT=csplit
+    CMD_DATE=("date" "-d")
     CMD_SHA="sha${DIGEST_SIZE}sum"
 fi
 
@@ -101,7 +105,7 @@ fi
 TSAs=()
 for f in $DIR_TS/*.tsr; do
     fbase=$(basename $f)
-    TSAs+=(${fbase:8:-4})
+    TSAs+=(${fbase:8:${#fbase}-12})
 done
 
 V_STATUS=()
@@ -115,7 +119,10 @@ for TSA_idx in $(seq 0 $((${#TSAs[@]}-1)) ); do
         2> >(grep -v "Using configuration from" >&2) )
     TS_HASH_ALG+=($(printf "%s" "$TS_R" | grep "Hash Algorithm" | cut -c 17- | tr -d " \n" | tr "[:lower:]" "[:upper:]"))
     TS_HASH_DIGEST+=($(printf "%s" "$TS_R" | grep "Message data" -A 2 | tail -2 | cut -c 12-58 | tr -d " \-\n"))
-    TS_EPOCH+=($(date -d "$(printf "%s" "$TS_R" | grep "Time stamp" | cut -c 12-)" +%s))
+    TS_TIME="$(printf "%s" "$TS_R" | grep "Time stamp" | cut -c 13-)"
+    # throw out milliseconds if present
+    TS_TIME=$(echo $TS_TIME | sed -E 's/([0-9]{2}:[0-9]{2}:[0-9]{2})\.[0-9]{3}/\1/g')
+    TS_EPOCH+=($("${CMD_DATE[@]}" "$TS_TIME" +%s))
 
     printf 'Verifying %s: ' "${TSAs[$TSA_idx]}"
 
@@ -126,7 +133,7 @@ for TSA_idx in $(seq 0 $((${#TSAs[@]}-1)) ); do
     # extract certificates from timestamp
     $DIR_BIN/ttsRepCert $DIR_TS/tsReply_${TSAs[$TSA_idx]}.tsr
     # split cert chain pem into individual certificates
-    csplit -s -f tsReply_${TSAs[$TSA_idx]} -b %02d.pem tsReply_${TSAs[$TSA_idx]}.pem /END\ CERTIFICATE/+2 {*}
+    $CMD_CSPLIT -s -f tsReply_${TSAs[$TSA_idx]} -b %02d.pem tsReply_${TSAs[$TSA_idx]}.pem /END\ CERTIFICATE/+2 {*}
     # delete empty file
     find $DIR_TMP -size 0 -delete
     # delete cert chain pem

--- a/trustedtimestamping/usr/local/bin/ttsVerify
+++ b/trustedtimestamping/usr/local/bin/ttsVerify
@@ -105,7 +105,7 @@ fi
 TSAs=()
 for f in $DIR_TS/*.tsr; do
     fbase=$(basename $f)
-    TSAs+=(${fbase:8:${#fbase}-12})
+    TSAs+=($(echo $fbase | cut -d'_' -f 2 | cut -d '.' -f 1))
 done
 
 V_STATUS=()


### PR DESCRIPTION
No functional changes here, just the following fixes for MacOS:
- base64: use `-b 0` (default and equivalent to `-w 0`)
- csplit: use gcsplit on mac (requires coreutils)
- syntax: 
  - [ -v ] -> [ -n ]. MacOS ships with /bin/bash that doesn't support the newer command
  - use `cut` since substring end lengths don't work in old bash version

Need to test on Linux before merging.